### PR TITLE
fix: fixes #24

### DIFF
--- a/src/test.py
+++ b/src/test.py
@@ -8,11 +8,40 @@ logging.getLogger("zlibrary").setLevel(logging.DEBUG)
 
 
 async def main():
-    lib = AsyncZlib()
-    await lib.login(os.environ.get('ZLOGIN'), os.environ.get('ZPASSW'))
+    # ensure environment variables are set
+    zlogin = os.environ.get('ZLOGIN')
+    zpassw = os.environ.get('ZPASSW')
+    assert zlogin is not None, "ZLOGIN environment variable is not set"
+    assert zpassw is not None, "ZPASSW environment variable is not set"
 
-    booklist = await lib.profile.search_public_booklists("test")
-    assert len(booklist.storage) > 0
+    lib = AsyncZlib()
+    await lib.login(zlogin, zpassw)
+
+    # ensure profile is initialized
+    assert hasattr(lib, 'profile') and lib.profile is not None, "lib.profile is not initialized after login"
+
+    # fleshed out booklist search
+    booklist_paginator = await lib.profile.search_public_booklists("test")
+    assert booklist_paginator is not None, "Booklist paginator is None"
+    booklists = await booklist_paginator.next()
+    assert isinstance(booklists, list), "Booklists is not a list"
+    assert len(booklists) > 0, "No booklists found"
+    print(f"Found {len(booklists)} public booklists matching 'test':")
+    for idx, bl in enumerate(booklists, 1):
+        assert 'name' in bl and bl['name'], f"Booklist {idx} missing name"
+        assert 'url' in bl and bl['url'], f"Booklist {idx} missing url"
+        print(f"[{idx}] Name: {bl.get('name')}, ID: {bl.get('url')}, Description: {bl.get('description')}, Books: {bl.get('count')}, Views: {bl.get('views')}")
+    
+    # fetch books from the first booklist
+    first_booklist = booklists[0]
+    await first_booklist.fetch()
+    books_in_list = first_booklist.storage.get(1, [])
+    assert isinstance(books_in_list, list), "Books in list is not a list"
+    print(f"First booklist contains {len(books_in_list)} books. Example:")
+    for i, book in enumerate(books_in_list[:3], 1):
+        assert 'name' in book and book['name'], f"Book {i} missing name"
+        assert 'id' in book and book['id'], f"Book {i} missing id"
+        print(f"  - {book.get('name')} (ID: {book.get('id')})")
 
     # count: 10 results per set
     paginator = await lib.search(q="biology", count=10)


### PR DESCRIPTION
I've fleshed out `test.py` with more assertions while debugging an issue with `BooklistItemPaginator` at https://github.com/sertraline/zlibrary/blob/c9acd4125e167fb5d3f82d9104387db06c53d64f/src/zlibrary/abs.py#L589 when running the following example from the readme similar to the issue in https://github.com/sertraline/zlibrary/issues/24.

```
bpage = await lib.profile.search_public_booklists(q="philosophy")

# get first 10 booklists
first_set = await bpage.next()
# get one booklist
booklist = first_set[0]
# get booklist data
booklist_data = await booklist.fetch()
```
```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[31], line 8
      6 booklist = first_set[0]
      7 # get booklist data
----> 8 booklist_data = await booklist.fetch()

File ~/app/monkeybutt/server/lib/python3.12/site-packages/zlibrary/abs.py:575, in BooklistItemPaginator.fetch(self)
    572 payload = f"papi/booklist/{get_id}/get-books"
    573 self.__url = f"{self.mirror}/{payload}"
--> 575 await self.init()
    577 self.parsed = parsed
    578 return parsed

File ~/app/monkeybutt/server/lib/python3.12/site-packages/zlibrary/abs.py:582, in BooklistItemPaginator.init(self)
    580 async def init(self):
    581     fjs = await self.fetch_json()
--> 582     await self.parse_json(fjs)
    583     return self

File ~/app/monkeybutt/server/lib/python3.12/site-packages/zlibrary/abs.py:589, in BooklistItemPaginator.parse_json(self, fjs)
    586 self.storage[self.page] = []
    588 fjs = json.loads(fjs)
--> 589 for book in fjs["books"]:
    590     js = BookItem(self.__r, self.mirror)
    592     js["id"] = book["book"]["id"]

KeyError: 'books'
```

I shall push a fix later during the day to this issue and update this PR.